### PR TITLE
feat: Support OpenAI-like providers

### DIFF
--- a/.autocommitmsg.yaml
+++ b/.autocommitmsg.yaml
@@ -1,0 +1,4 @@
+base-url: https://generativelanguage.googleapis.com/v1beta/openai
+api-key: GEMINI_API_KEY
+short-model: gemini-2.5-flash-lite
+long-model: gemini-2.5-flash

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@ devenv.local.nix
 
 # Project specific
 .env
-auto-commit-msg
+autocommitmsg
 result
 templates/default/devenv.lock

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,9 +80,7 @@ func (client OpenAIClient) createChatCompletion(model string, input []Message) (
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		fmt.Printf("%v\n", res)
-		// TODO: Extract error message from response
-		return nil, errors.New("TODO")
+		return nil, fmt.Errorf("response status code is not 200: %+v", res)
 	}
 
 	var data CreatedResponse
@@ -167,7 +165,7 @@ var rootCmd = &cobra.Command{
 			cobra.CheckErr(err)
 		}
 		if len(res.Choices) == 0 {
-			cobra.CheckErr(fmt.Sprintf("TODO: %v", res.Choices))
+			cobra.CheckErr(fmt.Sprintf("expects response to include at least one choice: %+v", res))
 		}
 
 		commitMsg := res.Choices[0].Message.Content

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -142,7 +141,7 @@ var rootCmd = &cobra.Command{
 
 		apiKey := os.Getenv(apiKeyEnvName)
 		if apiKey == "" {
-			cobra.CheckErr("environment variable OPENAI_API_KEY is required")
+			cobra.CheckErr(fmt.Sprintf("environment variable %s is required", apiKeyEnvName))
 		}
 
 		baseUrl := viper.GetString("base-url")


### PR DESCRIPTION
This commit introduces the necessary changes to integrate with the Generative Language API, allowing for the use of Gemini models for generating commit messages.

Key changes include:

- Added `.autocommitmsg.yaml` to configure API base URL, API key environment variable name, and model names.
- Modified `autocommitmsg` executable to support reading configuration from the YAML file.
- Updated `cmd/root.go` to:
    - Introduce `baseUrl` field in `OpenAIClient`.
    - Refactor `createResponse` to `createChatCompletion` to align with the new API structure.
    - Update the `CreateResponse`, `Input`, `CreatedResponse`, `Output`, and `Content` structs to match the expected JSON structure of the Generative Language API's chat completions endpoint.
    - Retrieve API key and base URL from Viper configuration.
    - Initialize `OpenAIClient` with the provided base URL.
    - Adjust response parsing to extract the commit message from the new response structure.
- Updated `initConfig` to set default values for `base-url` and `api-key` in Viper.
